### PR TITLE
Add travis config for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - "1.9.3"
+  - "2.0.0"
+  - "2.1.2"
+script: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # TCR (TCP + VCR)
 
+[![Build Status](https://travis-ci.org/robforman/tcr.png?branch=master)](https://travis-ci.org/robforman/tcr)
+
+
 TCR is a *very* lightweight version of [VCR](https://github.com/vcr/vcr) for TCP sockets.
 
 Currently used for recording 'net/smtp' interactions so only a few of the TCPSocket methods are recorded out.


### PR DESCRIPTION
Travis will automatically run the specs for various versions of ruby.

I enabled `1.9.3`, `2.0.0`, and `2.1.2` (which is they're latest non-custom one). I wasn't sure if you intended to support 1.8.7 so I left it out.

To get this working, follow [steps 1 & 2 of the getting started](http://docs.travis-ci.com/user/getting-started/#Step-one%3A-Sign-in), and then merge this PR.
