### PR TITLE
Shim for Socket.tcp

### DIFF
--- a/lib/tcr.rb
+++ b/lib/tcr.rb
@@ -82,3 +82,17 @@ class OpenSSL::SSL::SSLSocket
     end
   end
 end
+
+class Socket
+  class << self
+    alias_method :real_tcp, :tcp
+
+    def tcp(host, port, socket_opts)
+      if TCR.configuration.hook_tcp_ports.include?(port)
+        TCR::RecordableTCPSocket.new(host, port, TCR.cassette)
+      else
+        real_tcp(host, port, socket_opts)
+      end
+    end
+  end
+end

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -308,4 +308,16 @@ describe TCR do
       end
     end
   end
+
+  it "replaces sockets created with Socket.tcp" do
+    TCR.configure { |c|
+      c.hook_tcp_ports = [23]
+      c.cassette_library_dir = "."
+    }
+
+    TCR.use_cassette("test") do
+      sock = Socket.tcp("towel.blinkenlights.nl", 23, {})
+      expect(sock).to be_a(TCR::RecordableTCPSocket)
+    end
+  end
 end


### PR DESCRIPTION
This pull request creates a shim for Socket.tcp, which is another entry point where tcp sockets can be created
http://ruby-doc.org/stdlib-2.0.0/libdoc/socket/rdoc/Socket.html#method-c-tcp

*edit* For example, the net-ldap library [uses it to initialize sockets](https://github.com/ruby-ldap/ruby-net-ldap/blob/e4c46a223a19feda78393a793711353aa1febdcd/lib/net/ldap/connection.rb#L710).

Thanks for maintaining this gem!