### PR TITLE
Support yaml as a fixture format

### DIFF
--- a/lib/tcr/cassette.rb
+++ b/lib/tcr/cassette.rb
@@ -8,7 +8,7 @@ module TCR
       if File.exists?(filename)
         @recording = false
         @contents = File.open(filename) { |f| f.read }
-        @sessions = JSON.parse(@contents)
+        @sessions = unmarshal(@contents)
       else
         @recording = true
         @sessions = []
@@ -31,14 +31,36 @@ module TCR
 
     def save
       if recording?
-        File.open(filename, "w") { |f| f.write(JSON.pretty_generate(@sessions)) }
+        File.open(filename, "w") { |f| f.write(marshal(@sessions)) }
       end
     end
 
     protected
 
+    def unmarshal(content)
+      case TCR.configuration.format
+      when "json"
+        JSON.parse(content)
+      when "yaml"
+        YAML.load(content)
+      else
+        raise RuntimeError.new "unrecognized format #{TCR.configuration.format}, please use `json` or `yaml`"
+      end
+    end
+
+    def marshal(content)
+      case TCR.configuration.format
+      when "json"
+        JSON.pretty_generate(content)
+      when "yaml"
+        YAML.dump(content)
+      else
+        raise RuntimeError.new "unrecognized format #{TCR.configuration.format}, please use `json` or `yaml`"
+      end
+    end
+
     def filename
-      "#{TCR.configuration.cassette_library_dir}/#{name}.json"
+      "#{TCR.configuration.cassette_library_dir}/#{name}.#{TCR.configuration.format}"
     end
   end
 end

--- a/lib/tcr/configuration.rb
+++ b/lib/tcr/configuration.rb
@@ -1,6 +1,6 @@
 module TCR
   class Configuration
-    attr_accessor :cassette_library_dir, :hook_tcp_ports, :block_for_reads
+    attr_accessor :cassette_library_dir, :hook_tcp_ports, :block_for_reads, :format
 
     def initialize
       reset_defaults!
@@ -10,6 +10,7 @@ module TCR
       @cassette_library_dir = "fixtures/tcr_cassettes"
       @hook_tcp_ports = []
       @block_for_reads = false
+      @format = "json"
     end
   end
 end

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -180,6 +180,20 @@ describe TCR do
       cassette_contents.include?("220 smtp.mandrillapp.com ESMTP").should == true
     end
 
+    it "records the tcp session data into the yaml file" do
+      TCR.configure { |c| c.format = "yaml" }
+
+      TCR.use_cassette("test") do
+        tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
+        io = Net::InternetMessageIO.new(tcp_socket)
+        line = io.readline
+        tcp_socket.close
+      end
+      cassette_contents = File.open("test.yaml") { |f| f.read }
+      cassette_contents.include?("---").should == true
+      cassette_contents.include?("220 smtp.mandrillapp.com ESMTP").should == true
+    end
+
     it "plays back tcp sessions without opening a real connection" do
       expect(TCPSocket).to_not receive(:real_open)
 

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -15,8 +15,10 @@ describe TCR do
 
   around(:each) do |example|
     File.unlink("test.json") if File.exists?("test.json")
+    File.unlink("test.yaml") if File.exists?("test.yaml")
     example.run
     File.unlink("test.json") if File.exists?("test.json")
+    File.unlink("test.yaml") if File.exists?("test.yaml")
   end
 
   describe ".configuration" do
@@ -155,6 +157,16 @@ describe TCR do
           tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
         end
       }.to change{ File.exists?("./test.json") }.from(false).to(true)
+    end
+
+    it "creates a cassette file on use with yaml" do
+      TCR.configure { |c| c.format = "yaml" }
+
+      expect {
+        TCR.use_cassette("test") do
+          tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
+        end
+      }.to change{ File.exists?("./test.yaml") }.from(false).to(true)
     end
 
     it "records the tcp session data into the file" do


### PR DESCRIPTION
This PR introduces a new option `format` in `TCR.configuration`. It defaults to `json` for backwards compatibility, but also introduces `yaml` as an available option. This was useful in my project because I ran into some encoding issues marshaling LDAP sessions with JSON. I didn't dig deeply into what the source problem was, but figured I would share this in case anyone preferred YAML as a format.

Happy to update docs, and add tests if this is interesting.