### PR TITLE
Introduce hit all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ TCR.turned_off do
 end
 ```
 
+To make sure all external calls really happened use `hit_all` option:
+
+```ruby
+class TCRTest < Test::Unit::TestCase
+  def test_example_dot_com
+    TCR.use_cassette('mandrill_smtp', hit_all: true) do
+      # There are previously recorded external calls.
+      # ExtraSessionsError will be raised as a result.
+    end
+  end
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ class TCRTest < Test::Unit::TestCase
 end
 ```
 
+You can also use the configuration option:
+
+```ruby
+TCR.configure do |c|
+  c.hit_all = true
+end
+```
 ## Contributing
 
 1. Fork it

--- a/lib/tcr.rb
+++ b/lib/tcr.rb
@@ -42,6 +42,7 @@ module TCR
     TCR.cassette = Cassette.new(name)
     yield
     TCR.cassette.save
+    TCR.cassette.check_hits_all_sesstions if options[:hit_all] == true
   ensure
     TCR.cassette = nil
   end

--- a/lib/tcr.rb
+++ b/lib/tcr.rb
@@ -42,7 +42,7 @@ module TCR
     TCR.cassette = Cassette.new(name)
     yield
     TCR.cassette.save
-    TCR.cassette.check_hits_all_sesstions if options[:hit_all] || configuration.hit_all
+    TCR.cassette.check_hits_all_sessions if options[:hit_all] || configuration.hit_all
   ensure
     TCR.cassette = nil
   end

--- a/lib/tcr.rb
+++ b/lib/tcr.rb
@@ -42,7 +42,7 @@ module TCR
     TCR.cassette = Cassette.new(name)
     yield
     TCR.cassette.save
-    TCR.cassette.check_hits_all_sesstions if options[:hit_all] == true
+    TCR.cassette.check_hits_all_sesstions if options[:hit_all] || configuration.hit_all
   ensure
     TCR.cassette = nil
   end

--- a/lib/tcr/cassette.rb
+++ b/lib/tcr/cassette.rb
@@ -35,6 +35,12 @@ module TCR
       end
     end
 
+    def check_hits_all_sesstions
+      if !recording?
+        raise ExtraSessionsError if !@sessions.empty?
+      end
+    end
+
     protected
 
     def unmarshal(content)

--- a/lib/tcr/cassette.rb
+++ b/lib/tcr/cassette.rb
@@ -35,7 +35,7 @@ module TCR
       end
     end
 
-    def check_hits_all_sesstions
+    def check_hits_all_sessions
       if !recording?
         raise ExtraSessionsError if !@sessions.empty?
       end

--- a/lib/tcr/configuration.rb
+++ b/lib/tcr/configuration.rb
@@ -1,6 +1,6 @@
 module TCR
   class Configuration
-    attr_accessor :cassette_library_dir, :hook_tcp_ports, :block_for_reads, :format
+    attr_accessor :cassette_library_dir, :hook_tcp_ports, :block_for_reads, :format, :hit_all
 
     def initialize
       reset_defaults!
@@ -11,6 +11,7 @@ module TCR
       @hook_tcp_ports = []
       @block_for_reads = false
       @format = "json"
+      @hit_all = false
     end
   end
 end

--- a/lib/tcr/errors.rb
+++ b/lib/tcr/errors.rb
@@ -2,5 +2,6 @@ module TCR
   class TCRError < StandardError; end
   class NoCassetteError < TCRError; end
   class NoMoreSessionsError < TCRError; end
+  class ExtraSessionsError < TCRError; end
   class DirectionMismatchError < TCRError; end
 end

--- a/spec/fixtures/multitest-extra-smtp.json
+++ b/spec/fixtures/multitest-extra-smtp.json
@@ -1,0 +1,46 @@
+[
+  [
+    [
+      "read",
+      "220 smtp.mandrillapp.com ESMTP\r\n"
+    ],
+    [
+      "write",
+      "EHLO localhost\r\n"
+    ],
+    [
+      "read",
+      "250-relay-5.us-east-1.relay-prod\r\n250-PIPELINING\r\n250-SIZE 26214400\r\n250-STARTTLS\r\n250-AUTH PLAIN LOGIN\r\n250-ENHANCEDSTATUSCODES\r\n250 8BITMIME\r\n"
+    ],
+    [
+      "write",
+      "QUIT\r\n"
+    ],
+    [
+      "read",
+      "221 2.0.0 Bye\r\n"
+    ]
+  ],
+  [
+    [
+      "read",
+      "220 mail.smtp2go.com ESMTP Exim 4.86 Wed, 02 Mar 2016 02:55:19 +0000\r\n"
+    ],
+    [
+      "write",
+      "EHLO localhost\r\n"
+    ],
+    [
+      "read",
+      "250-mail.smtp2go.com Hello localhost [50.160.254.134]\r\n250-SIZE 52428800\r\n250-8BITMIME\r\n250-DSN\r\n250-PIPELINING\r\n250-AUTH CRAM-MD5 PLAIN LOGIN\r\n250-STARTTLS\r\n250-PRDR\r\n250 HELP\r\n"
+    ],
+    [
+      "write",
+      "QUIT\r\n"
+    ],
+    [
+      "read",
+      "221 mail.smtp2go.com closing connection\r\n"
+    ]
+  ]
+]

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -33,6 +33,10 @@ describe TCR do
      it "defaults to erroring on read/write mismatch access" do
        TCR.configuration.block_for_reads.should be_falsey
      end
+     
+     it "defaults to hit all to false" do
+       TCR.configuration.hit_all.should be_falsey
+     end
    end
 
    describe ".configure" do
@@ -52,6 +56,12 @@ describe TCR do
        expect {
          TCR.configure { |c| c.block_for_reads = true }
        }.to change{ TCR.configuration.block_for_reads }.from(false).to(true)
+     end
+     
+     it "configures to check if all sesstions was hit" do
+       expect {
+         TCR.configure { |c| c.hit_all = true }
+       }.to change{ TCR.configuration.hit_all }.from(false).to(true)
      end
    end
 

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -332,6 +332,14 @@ describe TCR do
           end
         }.to raise_error(TCR::NoMoreSessionsError)
       end
+
+      it "raises an error if you try to playback less sessions than you previously recorded" do
+        expect {
+          TCR.use_cassette("spec/fixtures/multitest-extra-smtp", hit_all: true) do
+            smtp = Net::SMTP.start("smtp.mandrillapp.com", 2525)
+          end
+        }.to raise_error(TCR::ExtraSessionsError)
+      end
     end
   end
 


### PR DESCRIPTION
Sometimes we need to know whether the external call really happened,
as without the call system isn't fully functioning.

Currently there will be no sign of the absence of the call. This PR changes
that by introducing the `hit_all` option. It will raise an exception
if any of the previously recorded sessions weren't hit.