### PR TITLE
Fixes issue #23: RuntimeError Exception: can't modify frozen String.

### DIFF
--- a/lib/tcr/recordable_tcp_socket.rb
+++ b/lib/tcr/recordable_tcp_socket.rb
@@ -87,7 +87,7 @@ module TCR
     def _write(method, data)
       if live
         @socket.__send__(method, data)
-        recording << ["write", data.to_s.force_encoding("UTF-8")]
+        recording << ["write", data.dup.to_s.force_encoding("UTF-8")]
       else
         direction, data = recording.shift
         _ensure_direction("write", direction)

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -364,4 +364,16 @@ describe TCR do
       expect(sock).to be_a(TCR::RecordableTCPSocket)
     end
   end
+
+  it "handles frozen Strings" do
+    TCR.configure { |c|
+      c.hook_tcp_ports = [443]
+      c.cassette_library_dir = "."
+    }
+
+    TCR.use_cassette("test") do
+      sock = TCPSocket.open("google.com", 443)
+      sock.print("hello\n".freeze)
+    end
+  end
 end


### PR DESCRIPTION
As described in issue #23 TCR fails in cases where frozen strings get written (e.g. IMAP).