### PR TITLE
Add test coverage and edge case fix for marshal format (expands #26)

### DIFF
--- a/lib/tcr/cassette.rb
+++ b/lib/tcr/cassette.rb
@@ -30,9 +30,10 @@ module TCR
     end
 
     def save
-      if recording?
-        File.open(filename, "w") { |f| f.write(marshal(@sessions)) }
-      end
+      return if !recording?
+      File.write(filename, marshal(@sessions))
+    rescue Encoding::UndefinedConversionError
+      File.binwrite(filename, marshal(@sessions))
     end
 
     def check_hits_all_sessions
@@ -52,7 +53,8 @@ module TCR
       when "marshal"
         Marshal.load(content)
       else
-        raise RuntimeError.new "unrecognized format #{TCR.configuration.format}, please use `json` or `yaml`"
+        raise "unrecognized cassette format '#{TCR.configuration.format}'; " \
+              "please use one of 'json', 'yaml', or 'marshal'"
       end
     end
 
@@ -65,7 +67,8 @@ module TCR
       when "marshal"
         Marshal.dump(content)
       else
-        raise RuntimeError.new "unrecognized format #{TCR.configuration.format}, please use `json` or `yaml`"
+        raise "unrecognized cassette format '#{TCR.configuration.format}'; " \
+              "please use one of 'json', 'yaml', or 'marshal'"
       end
     end
 

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -10,7 +10,7 @@ require 'thread'
 require "mail"
 
 
-describe TCR do
+RSpec.describe TCR do
   before(:each) do
     TCR.configuration.reset_defaults!
   end
@@ -165,57 +165,86 @@ describe TCR do
       expect(TCR.cassette).to be_nil
     end
 
-    it "creates a cassette file on use" do
-      expect {
-        TCR.use_cassette("test") do
-          tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
-        end
-      }.to change{ File.exists?("./test.json") }.from(false).to(true)
-    end
-
-    it "creates a cassette file on use with yaml" do
-      TCR.configure { |c| c.format = "yaml" }
-
-      expect {
-        TCR.use_cassette("test") do
-          tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
-        end
-      }.to change{ File.exists?("./test.yaml") }.from(false).to(true)
-    end
-
-    it "creates a cassette file on use with marshal" do
-      TCR.configure { |c| c.format = "marshal" }
-
-      expect {
-        TCR.use_cassette("test") do
-          tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
-        end
-      }.to change{ File.exists?("./test.marshal") }.from(false).to(true)
-    end
-
-    it "records the tcp session data into the file" do
-      TCR.use_cassette("test") do
-        tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
-        io = Net::InternetMessageIO.new(tcp_socket)
-        line = io.readline
-        tcp_socket.close
+    context 'when configured for JSON format' do
+      it "creates a cassette file on use" do
+        expect {
+          TCR.use_cassette("test") do
+            tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
+          end
+        }.to change{ File.exists?("./test.json") }.from(false).to(true)
       end
-      cassette_contents = File.open("test.json") { |f| f.read }
-      cassette_contents.include?("220 smtp.mandrillapp.com ESMTP").should == true
+
+      it "records the tcp session data into the file" do
+        TCR.use_cassette("test") do
+          tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
+          io = Net::InternetMessageIO.new(tcp_socket)
+          line = io.readline
+          tcp_socket.close
+        end
+        cassette_contents = File.open("test.json") { |f| f.read }
+        cassette_contents.include?("220 smtp.mandrillapp.com ESMTP").should == true
+      end
     end
 
-    it "records the tcp session data into the yaml file" do
-      TCR.configure { |c| c.format = "yaml" }
+    context 'when configured for YAML format' do
+      before { TCR.configure { |c| c.format = "yaml" } }
 
-      TCR.use_cassette("test") do
-        tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
-        io = Net::InternetMessageIO.new(tcp_socket)
-        line = io.readline
-        tcp_socket.close
+      it "creates a cassette file on use with yaml" do
+        expect {
+          TCR.use_cassette("test") do
+            tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
+          end
+        }.to change{ File.exists?("./test.yaml") }.from(false).to(true)
       end
-      cassette_contents = File.open("test.yaml") { |f| f.read }
-      cassette_contents.include?("---").should == true
-      cassette_contents.include?("220 smtp.mandrillapp.com ESMTP").should == true
+
+      it "records the tcp session data into the yaml file" do
+        TCR.use_cassette("test") do
+          tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
+          io = Net::InternetMessageIO.new(tcp_socket)
+          line = io.readline
+          tcp_socket.close
+        end
+        cassette_contents = File.open("test.yaml") { |f| f.read }
+        cassette_contents.include?("---").should == true
+        cassette_contents.include?("220 smtp.mandrillapp.com ESMTP").should == true
+      end
+    end
+
+    context 'when configured for Marshal format' do
+      before { TCR.configure { |c| c.format = "marshal" } }
+
+      it "creates a cassette file on use with marshal" do
+        expect {
+          TCR.use_cassette("test") do
+            tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
+          end
+        }.to change{ File.exists?("./test.marshal") }.from(false).to(true)
+      end
+
+      it "records the tcp session data into the marshalled file" do
+        TCR.use_cassette("test") do
+          tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
+          io = Net::InternetMessageIO.new(tcp_socket)
+          line = io.readline
+          tcp_socket.close
+        end
+        unmarshalled_cassette = Marshal.load(File.read("test.marshal"))
+        expect(unmarshalled_cassette).to be_a(Array)
+        expect(unmarshalled_cassette.first.last.last).to eq("220 smtp.mandrillapp.com ESMTP\r\n")
+      end
+
+      context "when Encoding.default_internal == Encoding::UTF_8 (as in Rails)" do
+        before { Encoding.default_internal = Encoding::UTF_8 }
+        let(:invalid_unicode_string) { "\u0001\u0001\u0004€" }
+
+        it "doesn't fail on cassettes with binary content" do
+          expect do
+            TCR.use_cassette("test") do
+              TCR.cassette.instance_variable_get(:@sessions) << ["read", invalid_unicode_string]
+            end
+          end.not_to raise_error
+        end
+      end
     end
 
     it "plays back tcp sessions without opening a real connection" do

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe TCR do
       expect(TCR.cassette).to be_nil
     end
 
-    context 'when configured for JSON format' do
+    context "when configured for JSON format" do
       it "creates a cassette file on use" do
         expect {
           TCR.use_cassette("test") do
@@ -186,7 +186,7 @@ RSpec.describe TCR do
       end
     end
 
-    context 'when configured for YAML format' do
+    context "when configured for YAML format" do
       before { TCR.configure { |c| c.format = "yaml" } }
 
       it "creates a cassette file on use with yaml" do
@@ -210,7 +210,7 @@ RSpec.describe TCR do
       end
     end
 
-    context 'when configured for Marshal format' do
+    context "when configured for Marshal format" do
       before { TCR.configure { |c| c.format = "marshal" } }
 
       it "creates a cassette file on use with marshal" do


### PR DESCRIPTION
This commit reorganizes and expands test coverage for the different TCR cassette formats (one of which was introduced in PR #26). It also fixes an edge case that occurs in Rails but not in plain Ruby, where trying to marshal and write non-Unicode sessions to disk cause an `EncodingError`.