### PR TITLE
Check path existence / file permissions for cassette file (fixes #28)

### DIFF
--- a/lib/tcr/cassette.rb
+++ b/lib/tcr/cassette.rb
@@ -1,22 +1,23 @@
+require 'fileutils'
+
 module TCR
   class Cassette
     attr_reader :name
 
     def initialize(name)
       @name = name
+      @sessions = recording? ? [] : unmarshal(File.read(filename))
 
-      if File.exists?(filename)
-        @recording = false
-        @contents = File.open(filename) { |f| f.read }
-        @sessions = unmarshal(@contents)
-      else
-        @recording = true
+      if recording?
+        verify_cassette_path_is_writable
         @sessions = []
+      else
+        @sessions = unmarshal(File.read(filename))
       end
     end
 
     def recording?
-      @recording
+      @recording ||= !File.exists?(filename)
     end
 
     def next_session
@@ -71,6 +72,11 @@ module TCR
 
     def filename
       "#{TCR.configuration.cassette_library_dir}/#{name}.#{TCR.configuration.format}"
+    end
+
+    def verify_cassette_path_is_writable
+      FileUtils.mkdir_p(File.dirname(filename))
+      FileUtils.touch(filename)
     end
   end
 end

--- a/lib/tcr/cassette.rb
+++ b/lib/tcr/cassette.rb
@@ -6,7 +6,6 @@ module TCR
 
     def initialize(name)
       @name = name
-      @sessions = recording? ? [] : unmarshal(File.read(filename))
 
       if recording?
         verify_cassette_path_is_writable

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -6,7 +6,6 @@ require "net/imap"
 require "net/smtp"
 require "net/ldap"
 require "tcr/net/ldap"
-require "thread"
 require "mail"
 
 


### PR DESCRIPTION
Also includes some indentation / trailing whitespace / formatting fixes to spec file.