### PR TITLE
Support recording & replaying TCP socket errors

### DIFF
--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -449,7 +449,7 @@ RSpec.describe TCR do
 
       # record cassette
       TCR.use_cassette("test") do
-        expect { Net::IMAP.new(nil) }.to raise_error(Errno::ECONNREFUSED)
+        expect { Net::IMAP.new(nil) }.to raise_error(SystemCallError)
       end
     end
 
@@ -460,7 +460,7 @@ RSpec.describe TCR do
 
     it "re-raises the error during replay" do
       TCR.use_cassette("test") do
-        expect { Net::IMAP.new(nil) }.to raise_error(Errno::ECONNREFUSED)
+        expect { Net::IMAP.new(nil) }.to raise_error(SystemCallError)
       end
     end
   end


### PR DESCRIPTION
### Background

I have tests which verify sad paths in my code – for instance,

```ruby
it 'requires a hostname' do
  TCR.use_cassette('test') do
    expect { Net::IMAP.new(nil) }.to raise_error(Errno::ECONNREFUSED)
  end
end
```

To clarify, this means that I **want `TCR.use_cassette` to raise an error** when replaying a cassette.

### Problem

Currently, if `TCPSocket.open` raises an error during recording, this results in an empty cassette file. When this cassette is replayed, `TCPRecordableSocket` has no way of knowing an error was originally raised; it chugs along until [this line](https://github.com/robforman/tcr/blob/master/lib/tcr/recordable_tcp_socket.rb#L23) tries to `#shift` an element off of an empty array, resulting in the following error:

```
     Failure/Error: expect { Net::IMAP.new(nil) }.to raise_error(Errno::ECONNREFUSED)

       expected Errno::ECONNREFUSED, got #<TCR::NoMoreSessionsError: TCR::NoMoreSessionsError> with backtrace:
         # ./lib/tcr/cassette.rb:27:in `next_session'
         # ./lib/tcr/recordable_tcp_socket.rb:23:in `initialize'
         # ./lib/tcr.rb:93:in `new'
         # ./lib/tcr.rb:93:in `tcp'
         # ./spec/tcr_spec.rb:480:in `new'
         # ./spec/tcr_spec.rb:480:in `block (4 levels) in <top (required)>'
         # ./spec/tcr_spec.rb:480:in `block (3 levels) in <top (required)>'
         # ./lib/tcr.rb:43:in `use_cassette'
         # ./spec/tcr_spec.rb:479:in `block (2 levels) in <top (required)>'
         # ./spec/tcr_spec.rb:21:in `block (2 levels) in <top (required)>'
     # ./spec/tcr_spec.rb:480:in `block (3 levels) in <top (required)>'
     # ./lib/tcr.rb:43:in `use_cassette'
     # ./spec/tcr_spec.rb:479:in `block (2 levels) in <top (required)>'
     # ./spec/tcr_spec.rb:21:in `block (2 levels) in <top (required)>'
```

### Fix

This PR extends TCR's existing `["read", "<message>"]` / `["write", "<message>"]` pattern for `@session` data, adding a `["error", "<marshalled exception>"]` session data type that is recorded when the error first occurs and is re-raised when replaying the cassette.

---

**Note:** I had to separately marshal the exception in this bugfix because of a funny bug I encountered with RSpec: serializing and then de-serializing an exception mostly works, but in my case, I wound up with an `Errno::ECONNREFUSED` object that was missing its original [`#errno` value](https://ruby-doc.org/core-2.5.0/SystemCallError.html#method-i-errno), which was causing the following strange behavior:

```ruby
>> err_obj
=> #<Errno::ECONNREFUSED: Connection refused - connect(2) for nil port 993>
>> err_obj.is_a?(Errno::ECONNREFUSED)
=> true       # this is correct
>> Errno::ECONNREFUSED === err_obj
=> false      # should be true, but is false because...
>> err_obj.errno
=> nil        # ...this is nil when it should be 111
```

And this would cause `expect { block }.to raise_error(Errno::ECONNREFUSED)` to fail instead of passing.