### PR TITLE
Upgrade for ruby 3.2.0

### DIFF
--- a/.github/workflows/tcr.yml
+++ b/.github/workflows/tcr.yml
@@ -21,6 +21,7 @@ jobs:
           - "2.5.1"
           - "2.7.3"
           - "3.0.1"
+          - "3.2.0"
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/tcr/cassette.rb
+++ b/lib/tcr/cassette.rb
@@ -16,7 +16,7 @@ module TCR
     end
 
     def recording?
-      @recording ||= !File.exists?(filename)
+      @recording ||= !File.exist?(filename)
     end
 
     def next_session

--- a/lib/tcr/version.rb
+++ b/lib/tcr/version.rb
@@ -1,3 +1,3 @@
 module TCR
-  VERSION = "0.4.0"
+  VERSION = "0.3.0"
 end

--- a/lib/tcr/version.rb
+++ b/lib/tcr/version.rb
@@ -1,3 +1,3 @@
 module TCR
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe TCR do
   end
 
   around(:each) do |example|
-    File.unlink("test.json") if File.exists?("test.json")
-    File.unlink("test.yaml") if File.exists?("test.yaml")
-    File.unlink("test.marshal") if File.exists?("test.marshal")
+    File.unlink("test.json") if File.exist?("test.json")
+    File.unlink("test.yaml") if File.exist?("test.yaml")
+    File.unlink("test.marshal") if File.exist?("test.marshal")
     example.run
-    File.unlink("test.json") if File.exists?("test.json")
-    File.unlink("test.yaml") if File.exists?("test.yaml")
-    File.unlink("test.marshal") if File.exists?("test.marshal")
+    File.unlink("test.json") if File.exist?("test.json")
+    File.unlink("test.yaml") if File.exist?("test.yaml")
+    File.unlink("test.marshal") if File.exist?("test.marshal")
   end
 
   describe ".configuration" do
@@ -214,7 +214,7 @@ RSpec.describe TCR do
           TCR.use_cassette("test") do
             tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
           end
-        }.to change{ File.exists?("./test.json") }.from(false).to(true)
+        }.to change{ File.exist?("./test.json") }.from(false).to(true)
       end
 
       it "records the tcp session data into the file" do
@@ -237,7 +237,7 @@ RSpec.describe TCR do
           TCR.use_cassette("test") do
             tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
           end
-        }.to change{ File.exists?("./test.yaml") }.from(false).to(true)
+        }.to change{ File.exist?("./test.yaml") }.from(false).to(true)
       end
 
       it "records the tcp session data into the yaml file" do
@@ -261,7 +261,7 @@ RSpec.describe TCR do
           TCR.use_cassette("test") do
             tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
           end
-        }.to change{ File.exists?("./test.marshal") }.from(false).to(true)
+        }.to change{ File.exist?("./test.marshal") }.from(false).to(true)
       end
 
       it "records the tcp session data into the marshalled file" do


### PR DESCRIPTION
Ruby 3.2.0 removed the `exists?` alias to `exist?` on the File:Class object. I refactored those usages.