### PR TITLE
CI: Configure dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
While reviewing the CI configuration, I saw an outdated GitHub Action, and this PR adds an auto-PRing for those versions, and also for gem dependencies.