### PR TITLE
Propagates positional and keyword arguments to the real_tcp method

### DIFF
--- a/lib/tcr.rb
+++ b/lib/tcr.rb
@@ -90,11 +90,11 @@ class Socket
   class << self
     alias_method :real_tcp, :tcp
 
-    def tcp(host, port, *socket_opts)
+    def tcp(host, port, *local_args, **timeout_opts)
       if TCR.configuration.hook_tcp_ports.include?(port)
         TCR::RecordableTCPSocket.new(host, port, TCR.cassette)
       else
-        real_tcp(host, port, *socket_opts)
+        real_tcp(host, port, *local_args, **timeout_opts)
       end
     end
   end

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -523,4 +523,18 @@ RSpec.describe TCR do
       end
     }.not_to raise_error
   end
+
+  context "when port is not in hook_tcp_ports" do
+    it "it honors Socket.tcp keyword arguments" do
+      TCR.configure { |c|
+        c.hook_tcp_ports = [8080]
+        c.cassette_library_dir = "."
+      }
+
+      TCR.use_cassette("test") do
+        sock = Socket.tcp("google.com", 80, connect_timeout: 1, resolv_timeout: 1)
+        expect(sock).to be_a(Socket)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because the `tcp` method on the `Socket` class also accept some keyword arguments, we need to properly forward those to the `real_tcp` call. Another option will be to directly remove all other optional args from the call.

The error that was raised was `TypeError: no implicit conversion of Hash into String`