### PR TITLE
Pin net-imap to version used to record cassettes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ gemspec
 
 gem "rspec"
 gem "mail"
+gem "net-imap", "0.2.2"
 gem "net-ldap"
 gem "mime-types"


### PR DESCRIPTION
Newer versions send additional commands that aren't in the cassette and break some tests